### PR TITLE
fix image url specialchars

### DIFF
--- a/catalog/controller/feed/hotline.php
+++ b/catalog/controller/feed/hotline.php
@@ -115,7 +115,7 @@ class ControllerFeedHotLine extends Controller {
                     $output .= '<url>' . $this->url->link('product/product', 'product_id=' . (int) $product['product_id']) . '</url>';
 
                     if ($product['image']) {
-                        $output .= '<image>' . $this->model_tool_image->resize($product['image'], 600, 600) . '</image>';
+                        $output .= '<image>' . htmlspecialchars( $this->model_tool_image->resize($product['image'], 600, 600) ) . '</image>';
                     }
 
                     // Prepare Price


### PR DESCRIPTION
Replace specialchars in image url.
eg. & -> amp;

(It was parse error when url contain &)